### PR TITLE
Windows 10 support - toast notifications

### DIFF
--- a/banner/banner_windows.go
+++ b/banner/banner_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package banner
+
+import (
+	"github.com/variadico/noti"
+	toast "github.com/jacobmarshall/go-toast"
+    "log"
+)
+
+// Notify displays a Windows 10 Toast Notification
+func Notify(n noti.Params) error {
+	 notification := toast.Notification{
+        AppID: "noti",
+        Title: n.Title,
+        Message: n.Message,
+        Icon: "",
+        Actions: nil}
+
+    err := notification.Push()
+
+    if err != nil {
+        log.Fatalln(err)
+    }
+    
+	return nil
+}

--- a/banner/banner_windows.go
+++ b/banner/banner_windows.go
@@ -3,25 +3,23 @@
 package banner
 
 import (
-	"github.com/variadico/noti"
 	toast "github.com/jacobmarshall/go-toast"
-    "log"
+	"github.com/variadico/noti"
+	"log"
 )
 
 // Notify displays a Windows 10 Toast Notification
-func Notify(n noti.Params) error {
-	 notification := toast.Notification{
-        AppID: "noti",
-        Title: n.Title,
-        Message: n.Message,
-        Icon: "",
-        Actions: nil}
+func Notify(n noti.Params) {
+	notification := toast.Notification{
+		AppID:   "noti",
+		Title:   n.Title,
+		Message: n.Message,
+		Icon:    "",
+		Actions: nil}
 
-    err := notification.Push()
+	if err != nil {
+		log.Fatalln(err)
+	}
 
-    if err != nil {
-        log.Fatalln(err)
-    }
-    
-	return nil
+	return notification.Push()
 }

--- a/cmd/noti/pollpid_windows.go
+++ b/cmd/noti/pollpid_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package main
+
+import (
+	"time"
+)
+
+// Not supported on Windows yet.
+func pollPID(pid int, interval time.Duration) error {
+	return nil
+}

--- a/speech/speech_windows.go
+++ b/speech/speech_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package speech
+
+import (
+	"github.com/variadico/noti"
+)
+
+// Notify via speech output is not supported on Windows yet, but we need it to be able to build the binary
+func Notify(n noti.Params) error {
+	return nil
+}


### PR DESCRIPTION
I was unable to run lint.sh on Windows, but I've run the following checks and I believe I'm all good.

```
go vet github.com/variadico/noti/...
golint github.com/variadico/noti/...
gofmt -d .
gofmt -s -d .
```

#### Description
Adds very basic Windows 10 support. Speech and PID polling are unsupported
 
#### Resolves
Ability to use noti on Windows. #36 is not yet fixed but it's a good step.