### PR TITLE
Update before_install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ os:
     - linux
 
 before_install:
-    - go get -u honnef.co/go/staticcheck/cmd/staticcheck
+    - go get -u honnef.co/go/tools/cmd/staticcheck
     - go get -u github.com/golang/lint/golint
-    - go get -u honnef.co/go/simple/cmd/gosimple
+    - go get -u honnef.co/go/tools/cmd/gosimple
 
 script:
     - go build -race ./...


### PR DESCRIPTION
#### Description
PRs are breaking because of a change of location of the `gosimple` and
`staticcheck` tools. This PR updates the location.

See the last 2 errors here: https://travis-ci.org/variadico/noti/jobs/217990087
