### PR TITLE
Allow custom Slackbot name

### DIFF
--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -76,7 +76,7 @@ func getSlack(title, message string, v *viper.Viper) notification {
 	return &slack.Notification{
 		Token:     v.GetString("slack.token"),
 		Channel:   v.GetString("slack.channel"),
-		Username:  "noti",
+		Username:  v.GetString("slack.username"),
 		Text:      fmt.Sprintf("%s\n%s", title, message),
 		IconEmoji: ":rocket:",
 

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -43,8 +43,9 @@ var baseDefaults = map[string]interface{}{
 	"simplepush.key":   "",
 	"simplepush.event": "",
 
-	"slack.token":   "",
-	"slack.channel": "",
+	"slack.token":    "",
+	"slack.channel":  "",
+	"slack.username": "noti",
 }
 
 func setNotiDefaults(v *viper.Viper) {
@@ -78,8 +79,9 @@ var keyEnvBindings = map[string]string{
 	"simplepush.key":   "NOTI_SIMPLEPUSH_KEY",
 	"simplepush.event": "NOTI_SIMPLEPUSH_EVENT",
 
-	"slack.token":   "NOTI_SLACK_TOK",
-	"slack.channel": "NOTI_SLACK_DEST",
+	"slack.token":    "NOTI_SLACK_TOK",
+	"slack.channel":  "NOTI_SLACK_DEST",
+	"slack.username": "NOTI_SLACK_USERNAME",
 }
 
 func bindNotiEnv(v *viper.Viper) {


### PR DESCRIPTION
#### Description
Currently, there is no way to customize the Slackbot name. It's hardcoded to `noti`. This adds a new config key to allow changing the name.

```yaml
slack:
  username: Pikwi
```

or 

```
NOTI_SLACK_USERNAME='Pikwi'
```

![image](https://user-images.githubusercontent.com/4296393/34318421-b9bfbc62-e78c-11e7-9ca4-452d09ad57f1.png)


#### Resolves
Resolves #57

cc @pascalandy