### PR TITLE
Increase freedesktop expire timeout

### DIFF
--- a/internal/command/local.go
+++ b/internal/command/local.go
@@ -15,7 +15,7 @@ func getBanner(title, message string, v *viper.Viper) notification {
 	return &freedesktop.Notification{
 		Summary:       title,
 		Body:          message,
-		ExpireTimeout: 500,
+		ExpireTimeout: 5000,
 		AppIcon:       "utilities-terminal",
 	}
 }


### PR DESCRIPTION
#### Description
Increases 500ms freedesktop expire timeout to 5s.

#### Resolves
Notification was visible way too short.
