### PR TITLE
Implemented pollPID for Windows and BSD kernels

### DIFF
--- a/internal/command/pollpid_bsd.go
+++ b/internal/command/pollpid_bsd.go
@@ -1,0 +1,66 @@
+// +build freebsd netbsd openbsd dragonfly darwin
+
+package command
+
+import "unsafe"
+import "strconv"
+import "syscall"
+import "time"
+import "errors"
+import "os"
+
+import "golang.org/x/sys/unix"
+
+func pollPID(pid int, _ time.Duration) error {
+        kq, err := syscall.Kqueue()
+
+        if err != nil {
+                return err
+        }
+
+        if kq < 0 {
+                return errors.New("kqueue failed with " + strconv.Itoa(-kq))
+        }
+
+        kqFile := os.NewFile(uintptr(kq), "kq")
+
+        defer kqFile.Close()
+
+        syscall.Syscall(syscall.SYS_FCNTL, uintptr(kq), syscall.F_SETFD, syscall.FD_CLOEXEC)
+
+        ev := make([]syscall.Kevent_t, 1, 1)
+
+        *(*int)(unsafe.Pointer(&ev[0].Ident)) = pid
+
+        ev[0].Filter = unix.EVFILT_PROC
+        ev[0].Flags = unix.EV_ADD
+        ev[0].Fflags = unix.NOTE_EXIT
+        ev[0].Data = 0
+        ev[0].Udata = nil
+
+        n, err := syscall.Kevent(kq, ev, nil, nil)
+
+        if err != nil {
+                return err
+        }
+
+        if n < 0 {
+                return errors.New("kevent failed with " + strconv.Itoa(-n))
+        }
+
+        for {
+                ev[0] = syscall.Kevent_t{}
+                n, err = syscall.Kevent(kq, nil, ev, nil)
+
+                if err != nil {
+                        return err
+                }
+
+                if (ev[0].Fflags & unix.NOTE_EXIT) != 0 {
+                        break
+                }
+        }
+
+        return nil
+}
+

--- a/internal/command/pollpid_unix.go
+++ b/internal/command/pollpid_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!freebsd,!netbsd,!openbsd,!dragonfly,!darwin
 
 package command
 

--- a/internal/command/pollpid_windows.go
+++ b/internal/command/pollpid_windows.go
@@ -1,10 +1,36 @@
+// +build windows
+
 package command
 
 import (
 	"errors"
 	"time"
+	"strconv"
+	"syscall"
 )
 
-func pollPID(_ int, _ time.Duration) error {
-	return errors.New("pwatch not supported on this platform")
+var (
+	kernel32 = syscall.NewLazyDLL("kernel32")
+
+	openProcess = kernel32.NewProc("OpenProcess")
+	waitForSingleObject = kernel32.NewProc("WaitForSingleObject")
+)
+
+const _SYNCHRONIZE = 0x00100000
+const _INFINITE = 0xFFFFFFFF
+
+func pollPID(pid int, _ time.Duration) error {
+	hProcess, _, lastError := openProcess.Call(_SYNCHRONIZE, 0, uintptr(pid))
+
+	if hProcess == 0 {
+		return errors.New("OpenProcess failed with " + lastError.Error())
+	}
+
+	result, _, lastError := waitForSingleObject.Call(hProcess, _INFINITE)
+
+	if result != 0 {
+		return errors.New("WaitForSingleObject failed with " + strconv.Itoa(int(result)) + ", last error " + lastError.Error())
+	}
+
+	return nil
 }


### PR DESCRIPTION
The `--pwatch` function presently only works on UNIX-like systems by means of crude polling. This polling is inexact and also suffers from an (admittedly rare) race condition to do with PID reuse. There are stronger implementations possible on Windows (by opening a handle to the process) and on BSD-type systems (leveraging `kqueue`).

This PR:

- Adds an implementation to the `pollpid_windows.go` stub.
- Creates a new implementation `pollpid_bsd.go` that uses `kqueue`. I have tested it on FreeBSD 11.0-RELEASE. `kqueue` is supposed to work the same way on NetBSD, OpenBSD, DragonflyBSD and Darwin, but I don't have access to those to test.

I have tested these changes in full integration with the `noti` binary as installed via `go get -u github.com/logiclrd/noti/cmd/noti` (the main line in my fork of the repo contains one extra commit to resolve the internal package reference in `main.go`).

This is my first time ever working with Go, and one issue that will probably need to be resolved is how to automatically pull in `golang.org/x/sys/unix` to permit the syscalls in `pollpid_unix.go`. I installed the dependency manually and it worked, but I'm assuming this isn't going to happen everywhere else -- and what happens on non-UNIX platforms if that's listed as a requirement??

I also tried running `make test` on my FreeBSD machine, and was told that it couldn't load package `.` because there were no `Go` files in the directory.