### PR TITLE
Add logic to read message from stdin with `--message=-`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ $ fg; noti
 2097152000 bytes (2.1 GB, 2.0 GiB) copied, 12 s, 175 MB/s
 ```
 
+Additionally, `noti` can send a message piped from stdin with `-`.
+
+```
+$ make test 2>&1 | tail --lines 5 | noti -t "Test Results" -m -
+```
+
 
 [CircleCI]: https://circleci.com/gh/variadico/noti/tree/master.svg?style=svg
 [AppVeyor]: https://ci.appveyor.com/api/projects/status/qc2fgc164786jws6/branch/master?svg=true

--- a/docs/man/noti.1.md
+++ b/docs/man/noti.1.md
@@ -21,7 +21,7 @@ when it's done. You can receive messages on your computer or phone.
 : Set notification title. Default is utility name.
 
 -m \<string\>, \--message \<string\>
-: Set notification message. Default is "Done!".
+: Set notification message. Default is "Done!". Read from stdin with "-".
 
 -b, \--banner
 : Trigger a banner notification. This is enabled by default. To disable this
@@ -118,6 +118,10 @@ If you already started a command, but forgot to use `noti`, then you can do
 this to get notified when that process' PID disappears.
 
     noti --pwatch $(pgrep docker-machine)
+
+Receive your message from stdin with `-`.
+
+    rsync -az --stats ~/  server:/backups/homedir | noti -t "backup stats" -m -
 
 # REPORTING BUGS
 

--- a/docs/noti.md
+++ b/docs/noti.md
@@ -63,7 +63,7 @@ curl -L $(curl -s https://api.github.com/repos/variadico/noti/releases/latest | 
     Set notification title.  Default is utility name.
 
 -m <string>, --message <string>
-    Set notification message.  Default is "Done!".
+    Set notification message.  Default is "Done!". Read from stdin with "-".
 
 -b, --banner
     Trigger a banner notification.  This is enabled by default.  To disable
@@ -272,6 +272,12 @@ this to get notified when that process' PID disappears.
 
 ```
 noti --pwatch $(pgrep docker-machine)
+```
+
+Receive your message from stdin with `-`.
+
+```
+rsync -az --stats ~/  server:/backups/homedir | noti -t "backup stats" -m -
 ```
 
 Sample configuration file.


### PR DESCRIPTION
This change supports using `noti` as the end of a pipeline of commands. Reading from standard input adds flexibility.

Say you had a deployment script that outputs an artifact path, some job statistics, and/or url for a canary instance. You could read that output and notify people when & where the deploy is available.

See the updated documentation for more.

Even MS-DOS Batch in `cmd.exe` supports pipes (and can't be replaced with command substitution).

A note about implementation: When reading from stdin, the typical use case of having `noti` run the given command in a subprocess will be skipped. This is because with that use, `noti` already feeds its stdin to the subprocess, so there's no 2nd standard input to consume, it just doesn't make sense logically.  
It could be argued that, when instructed with `-m -` and a typical sub-command, that `noti` should read the stdout of the subprocess as a message, but that is unconventional and doesn't provide opportunity to further manipulate the output as pipes do.

-----

This was originally requested in #44 . I saw the suggestion and thought it would be fun to hack on this nifty utility I've used for years. I hope the stealth PR is ok (I actually have another one).

Resolves #44 