### PR TITLE
Add support for keybase

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Banner     |   ✔   |   ✔   |    ✔
 Speech     |   ✔   |   ✔   |    ✔
 BearyChat  |   ✔   |   ✔   |    ✔
 HipChat    |   ✔   |   ✔   |    ✔
+Keybase    |   ✔   |   ✔   |    ✔
 Mattermost |   ✔   |   ✔   |    ✔
 Pushbullet |   ✔   |   ✔   |    ✔
 Pushover   |   ✔   |   ✔   |    ✔

--- a/docs/man/noti.1.md
+++ b/docs/man/noti.1.md
@@ -40,6 +40,10 @@ when it's done. You can receive messages on your computer or phone.
 : Trigger a HipChat notification. This requires `hipchat.accessToken` and
   `hipchat.room` to be set.
 
+--keybase
+: Trigger a Keybase notification. This requires `keybase.conversation` to
+  be set.
+
 -p, \--pushbullet
 : Trigger a Pushbullet notification. This requires `pushbullet.accessToken` to
   be set.
@@ -84,6 +88,10 @@ when it's done. You can receive messages on your computer or phone.
 * `NOTI_BEARYCHAT_INCOMINGHOOKURI`
 * `NOTI_HIPCHAT_ACCESSTOKEN`
 * `NOTI_HIPCHAT_ROOM`
+* `NOTI_KEYBASE_CONVERSATION`
+* `NOTI_KEYBASE_CHANNEL`
+* `NOTI_KEYBASE_PUBLIC`
+* `NOTI_KEYBASE_EXPLODINGLIFETIME`
 * `NOTI_PUSHBULLET_ACCESSTOKEN`
 * `NOTI_PUSHBULLET_DEVICEIDEN`
 * `NOTI_PUSHOVER_APITOKEN`

--- a/docs/man/noti.yaml.5.md
+++ b/docs/man/noti.yaml.5.md
@@ -64,6 +64,23 @@ accessToken
 room
 : HipChat message destination. Can be either a Room name or ID.
 
+# KEYBASE
+
+conversation
+: Keybase message destination. Can be either users (comma-separated) or team.
+
+channel
+: Keybase team's chat channel to send to. Conversation must be a team.
+  If empty, the team's default channel will be used (typically "general").
+
+explodingLifetime
+: Keybase self-destructing message, after the specified time. Times are
+  written like `30s` (30 seconds), `15m` (15 minutes), `24h` (24 hours).
+
+public
+: Enables broadcasting a message to everyone (when `conversation` is
+  your username), or to teams (when `conversation` is your team name).
+
 # PUSHBULLET
 
 accessToken
@@ -125,6 +142,9 @@ username
     hipchat:
       accessToken: 1234567890abcdefg
       room: 1234567890abcdefg
+    keybase:
+      conversation: yourteam
+      channel: general
     pushbullet:
       accessToken: 1234567890abcdefg
       deviceIden: 1234567890abcdefg

--- a/docs/noti.md
+++ b/docs/noti.md
@@ -26,6 +26,7 @@ Banner     |   ✔   |   ✔   |    ✔
 Speech     |   ✔   |   ✔   |    ✔
 BearyChat  |   ✔   |   ✔   |    ✔
 HipChat    |   ✔   |   ✔   |    ✔
+Keybase    |   ✔   |   ✔   |    ✔
 Pushbullet |   ✔   |   ✔   |    ✔
 Pushover   |   ✔   |   ✔   |    ✔
 Pushsafer  |   ✔   |   ✔   |    ✔
@@ -82,6 +83,10 @@ curl -L $(curl -s https://api.github.com/repos/variadico/noti/releases/latest | 
     Trigger a HipChat notification.  This requires hipchat.accessToken and
     hipchat.room to be set.
 
+--keybase
+    Trigger a Keybase notification.  This requires keybase.conversation
+    to be set.
+
 -p, --pushbullet
     Trigger a Pushbullet notification.  This requires pushbullet.accessToken
     to be set.
@@ -100,7 +105,7 @@ curl -L $(curl -s https://api.github.com/repos/variadico/noti/releases/latest | 
 -k, --slack
     Trigger a Slack notification.  This requires slack.token and
     slack.channel to be set.
-    
+
 -g, --telegram
     Trigger a Telegram notification.  This requires telegeram.token and
     telegram.chatId to be set.
@@ -133,6 +138,10 @@ curl -L $(curl -s https://api.github.com/repos/variadico/noti/releases/latest | 
 * `NOTI_BEARYCHAT_INCOMINGHOOKURI`
 * `NOTI_HIPCHAT_ACCESSTOKEN`
 * `NOTI_HIPCHAT_ROOM`
+* `NOTI_KEYBASE_CONVERSATION`
+* `NOTI_KEYBASE_CHANNEL`
+* `NOTI_KEYBASE_PUBLIC`
+* `NOTI_KEYBASE_EXPLODINGLIFETIME`
 * `NOTI_PUSHBULLET_ACCESSTOKEN`
 * `NOTI_PUSHBULLET_DEVICEIDEN`
 * `NOTI_PUSHOVER_APITOKEN`
@@ -200,6 +209,23 @@ accessToken
 room
     HipChat message destination. Can be either a Room name or ID.
 
+KEYBASE
+
+conversation
+    Keybase message destination. Can be either users (comma-separated) or team.
+
+channel
+    Keybase team's chat channel to send to. Conversation must be a team.
+    If empty, the team's default channel will be used (typically "general").
+
+explodingLifetime
+    Keybase self-destructing message, after the specified time. Times are
+    written like `30s` (30 seconds), `15m` (15 minutes), `24h` (24 hours).
+
+public
+    Enables broadcasting a message to everyone (when `conversation` is
+    your username), or to teams (when `conversation` is your team name).
+
 PUSHBULLET
 
 accessToken
@@ -243,12 +269,12 @@ channel
 
 username
     Noti bot username.
-    
+
 TELEGRAM
 
 token
     Telegram access token. The token can be retrieved using the [BotFather](https://telegram.me/botfather)
-    
+
 chatId
     Telegram message destination: Can be either a chat or a channel
 ```
@@ -291,6 +317,9 @@ bearychat:
 hipchat:
   accessToken: 1234567890abcdefg
   room: 1234567890abcdefg
+keybase:
+  conversation: yourteam
+  channel: general
 pushbullet:
   accessToken: 1234567890abcdefg
   deviceIden: 1234567890abcdefg
@@ -329,6 +358,17 @@ you'll set `hipchat.accessToken` to.
 Next, go to My Account > Rooms > {pick a room} > Summary. Look for "API ID". You
 can set `hipchat.room` to "API ID" or you can use the Room name, like
 "MyRoom".
+
+### Keybase
+
+Log into your [Keybase] account and go to the Chat section.
+Pick a team or user to send to, and set your `keybase.conversation` to that
+name. For teams, you can also specify a channel with `keybase.channel` or have
+it send to `general`. You can also send notifications that auto-delete with
+`keybase.explodingLifetime` set between `30s` (seconds) to `168h` (hours).
+
+As long as the keybase service is running and the `keybase` binary is in your
+system path, you should be all set.
 
 ### Pushbullet
 
@@ -386,3 +426,4 @@ Report bugs on GitHub at https://github.com/variadico/noti/issues.
 [Pushsafer]: https://www.pushsafer.com
 [OAuth Tokens for Testing and Development]: https://api.slack.com/docs/oauth-test-tokens
 [bc-incoming]: https://bearychat.com/integrations/incoming
+[Keybase]: https://keybase.io/download

--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/variadico/noti/service/bearychat"
 	"github.com/variadico/noti/service/hipchat"
+	"github.com/variadico/noti/service/keybase"
 	"github.com/variadico/noti/service/mattermost"
 	"github.com/variadico/noti/service/pushbullet"
 	"github.com/variadico/noti/service/pushover"
@@ -36,6 +37,28 @@ func getHipChat(title, message string, v *viper.Viper) notification {
 		Message:       fmt.Sprintf("%s\n%s", title, message),
 		MessageFormat: "text",
 		Client:        httpClient,
+	}
+}
+
+func getKeybase(title, message string, v *viper.Viper) notification {
+	var explodeTime time.Duration
+	if v.GetString("keybase.explodingLifetime") != "" {
+		// Error handling: if explodingLifetime is set to a unparseable duration,
+		// viper will assign it to zero. Replace with -1, which will cause an early
+		// error, to ensure the command does not send a regular message on accident.
+		// Keybase's exploding messages have stricter security guarantees.
+		explodeTime = v.GetDuration("keybase.explodingLifetime")
+		if explodeTime == 0 {
+			explodeTime = -1
+		}
+	}
+
+	return &keybase.Notification{
+		Conversation:      v.GetString("keybase.conversation"),
+		ChannelName:       v.GetString("keybase.channel"),
+		Public:            v.GetBool("keybase.public"),
+		ExplodingLifetime: explodeTime,
+		Message:           fmt.Sprintf("**%s**\n%s", title, message),
 	}
 }
 

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -39,6 +39,11 @@ var baseDefaults = map[string]interface{}{
 	"hipchat.accessToken": "",
 	"hipchat.room":        "",
 
+	"keybase.conversation":      "",
+	"keybase.channel":           "",
+	"keybase.public":            "",
+	"keybase.explodingLifetime": "",
+
 	"pushbullet.accessToken": "",
 	"pushbullet.deviceIden":  "",
 
@@ -89,6 +94,11 @@ var keyEnvBindings = map[string]string{
 
 	"hipchat.accessToken": "NOTI_HIPCHAT_ACCESSTOKEN",
 	"hipchat.room":        "NOTI_HIPCHAT_ROOM",
+
+	"keybase.conversation":      "NOTI_KEYBASE_CONVERSATION",
+	"keybase.channel":           "NOTI_KEYBASE_CHANNEL",
+	"keybase.public":            "NOTI_KEYBASE_PUBLIC",
+	"keybase.explodingLifetime": "NOTI_KEYBASE_EXPLODINGLIFETIME",
 
 	"pushbullet.accessToken": "NOTI_PUSHBULLET_ACCESSTOKEN",
 	"pushbullet.deviceIden":  "NOTI_PUSHBULLET_DEVICEIDEN",
@@ -234,6 +244,7 @@ func enabledFromSlice(defaults []string) map[string]bool {
 		"banner":     false,
 		"bearychat":  false,
 		"hipchat":    false,
+		"keybase":    false,
 		"pushbullet": false,
 		"pushover":   false,
 		"pushsafer":  false,
@@ -261,6 +272,7 @@ func hasServiceFlags(flags *pflag.FlagSet) bool {
 		"banner":     false,
 		"bearychat":  false,
 		"hipchat":    false,
+		"keybase":    false,
 		"pushbullet": false,
 		"pushover":   false,
 		"pushsafer":  false,
@@ -291,6 +303,7 @@ func enabledFromFlags(flags *pflag.FlagSet) map[string]bool {
 		"banner":     false,
 		"bearychat":  false,
 		"hipchat":    false,
+		"keybase":    false,
 		"pushbullet": false,
 		"pushover":   false,
 		"pushsafer":  false,
@@ -362,6 +375,10 @@ func getNotifications(v *viper.Viper, services map[string]struct{}) []notificati
 
 	if _, ok := services["hipchat"]; ok {
 		notis = append(notis, getHipChat(title, message, v))
+	}
+
+	if _, ok := services["keybase"]; ok {
+		notis = append(notis, getKeybase(title, message, v))
 	}
 
 	if _, ok := services["pushbullet"]; ok {

--- a/internal/command/config_test.go
+++ b/internal/command/config_test.go
@@ -338,6 +338,7 @@ func TestGetNotifications(t *testing.T) {
 		"banner",
 		"bearychat",
 		"hipchat",
+		"keybase",
 		"pushbullet",
 		"pushover",
 		"pushsafer",

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -51,6 +51,7 @@ func InitFlags(flags *pflag.FlagSet) {
 	flags.BoolP("speech", "s", false, "Trigger a speech notification.")
 	flags.BoolP("bearychat", "c", false, "Trigger a BearyChat notification.")
 	flags.BoolP("hipchat", "i", false, "Trigger a HipChat notification.")
+	flags.Bool("keybase", false, "Trigger a Keybase notification.")
 	flags.BoolP("pushbullet", "p", false, "Trigger a Pushbullet notification.")
 	flags.BoolP("pushover", "o", false, "Trigger a Pushover notification.")
 	flags.BoolP("pushsafer", "u", false, "Trigger a Pushsafer notification.")

--- a/service/keybase/keybase.go
+++ b/service/keybase/keybase.go
@@ -1,0 +1,76 @@
+package keybase
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// KeybaseBin is cli binary
+const KeybaseBin = "keybase"
+
+// Errors when parsing notification settings
+var (
+	ErrorMissingConversation = errors.New("keybase: missing conversation (team or username) to send to")
+	ErrorMissingMessage      = errors.New("keybase: missing message content")
+	ErrorBadExplodingTime    = errors.New("keybase: explodingLifetime must be a time between 30s and 168h0m0s")
+)
+
+// Notification is a Keybase notification.
+type Notification struct {
+	// Conversation is the team name or users (comma-separated) to notify.
+	Conversation string
+	// ChannelName is the team's chat channel to send to. If empty, the team's
+	// default channel will be used (typically "general").
+	ChannelName string
+	// Public toggles broadcasting a message to everyone (when Conversation is your
+	// username), or to teams (when Conversation is your team name).
+	Public bool
+	// ExplodingLifetime will delete the message in the time given.
+	ExplodingLifetime time.Duration
+	// Message contents to be sent
+	Message string
+}
+
+// prepareArgs builds the `keybase` cli arguments from the Notification settings
+func prepareArgs(n *Notification) ([]string, error) {
+	switch {
+	case n.Conversation == "":
+		return nil, ErrorMissingConversation
+	case n.Message == "":
+		return nil, ErrorMissingMessage
+	case n.ExplodingLifetime < 0:
+		return nil, ErrorBadExplodingTime
+	}
+
+	args := []string{"chat", "send"}
+	if n.ChannelName != "" {
+		args = append(args, "--channel", n.ChannelName)
+	}
+	if n.Public {
+		args = append(args, "--public")
+	}
+	if n.ExplodingLifetime > 0 {
+		args = append(args, "--exploding-lifetime", fmt.Sprint(n.ExplodingLifetime))
+	}
+	args = append(args, n.Conversation, n.Message)
+	return args, nil
+}
+
+// Send triggers a Keybase notification.
+func (n *Notification) Send() error {
+	args, err := prepareArgs(n)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(KeybaseBin, args...)
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("keybase: command error: %v", err)
+	}
+	return nil
+}

--- a/service/keybase/keybase_test.go
+++ b/service/keybase/keybase_test.go
@@ -1,0 +1,71 @@
+package keybase
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestKeybase_prepareArgs(t *testing.T) {
+	// Initial args to the keybase cli
+	base := []string{"chat", "send"}
+
+	cases := []struct {
+		name string
+		// input
+		n *Notification
+		// expected outputs
+		args []string
+		err  error
+	}{
+		{
+			name: "Minimal keybase notification",
+			n:    &Notification{Conversation: "capn_picard", Message: "salutations"},
+			args: append(base, "capn_picard", "salutations"),
+			err:  nil,
+		},
+		{
+			name: "Channel specified notification",
+			n: &Notification{
+				Conversation:      "golang-dev",
+				ChannelName:       "off-topic",
+				Message:           "salutations",
+				ExplodingLifetime: 30 * time.Minute,
+			},
+			args: append(base, "--channel", "off-topic", "--exploding-lifetime", "30m0s", "golang-dev", "salutations"),
+			err:  nil,
+		},
+		{
+			name: "Missing required `Conversation`",
+			n:    &Notification{Conversation: "", Message: "salutations"},
+			args: nil,
+			err:  ErrorMissingConversation,
+		},
+		{
+			name: "Missing required `Message`",
+			n:    &Notification{Conversation: "homer", Message: ""},
+			args: nil,
+			err:  ErrorMissingMessage,
+		},
+		{
+			name: "Invalid exploding time",
+			n:    &Notification{Conversation: "biggie", Message: "salutations", ExplodingLifetime: -1},
+			args: nil,
+			err:  ErrorBadExplodingTime,
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := prepareArgs(tt.n)
+			if !reflect.DeepEqual(args, tt.args) {
+				t.Errorf("got wrong args: have=%v; want=%v;", args, tt.args)
+			}
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("got wrong error: have=%v; want=%v;", err, tt.err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Keybase (https://keybase.io/) is a secure chat/file/social network. Keybase provides e2e encryption on everything, making it an enticing platform for security conscious people. Most of the features of it's chat are described [in the announcement post][keybase-chat], though there are a few new ones since then (like self-destructing messages).

Implementing keybase support in `noti` required leveraging the `keybase` cli command. Keybase has "APIs" like any platform, but due to the crypto involved, they are difficult to interact with directly. The `keybase` command does the IPC with the keybase service and encrypted filesystem. By leveraging the cli, it handles the user identity information for us.

It's hard to automate an exhaustive test for keybase without making a full blown integration test that requires the cli, but I can test most of the setup. I was able to add tests for the errors noti can generate for the set of keybase options.

I also updated all noti documentation (readme, man pages). Due to the increasing number of integrations supported, I opted to provide only a long option (`--keybase`) for this. Plus, `-k` was already taken (by slack!)

-----

This idea comes from #103 . I picked it up as a regular user of keybase who wanted to dig into the API more.
That issue #103 also mentions the keybase chatbot lib for golang, which is beyond the scope of what we need here. It too, leverages the `keybase` cli tool, so it really seems like a hard requirement.

If you dislike the idea of adding a feature to `noti` that requires a separate, large application/server install, then I understand leaving this out. It's up to you, I know it's a tough job maintaining projects like this and keeping feature creep in check.

Resolves #103 

[keybase-chat]: https://keybase.io/blog/keybase-chat