### PR TITLE
Add --time option

### DIFF
--- a/docs/noti.md
+++ b/docs/noti.md
@@ -65,6 +65,9 @@ curl -L $(curl -s https://api.github.com/repos/variadico/noti/releases/latest | 
 -m <string>, --message <string>
     Set notification message.  Default is "Done!". Read from stdin with "-".
 
+-e, --time
+    Show command execution time in message.
+
 -b, --banner
     Trigger a banner notification.  This is enabled by default.  To disable
     this service, set this flag to false.  This will be either nsuser,

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -24,6 +24,7 @@ import (
 var baseDefaults = map[string]interface{}{
 	"defaults": []string{"banner"},
 	"message":  "Done!",
+	"time":     false,
 
 	"nsuser.soundName":     "Ping",
 	"nsuser.soundNameFail": "Basso",

--- a/internal/command/config_test.go
+++ b/internal/command/config_test.go
@@ -28,6 +28,11 @@ func countSettingsKeys(t *testing.T, m map[string]interface{}) int {
 			// v is just a string key.
 			keys++
 		}
+
+		if _, ok := v.(bool); ok {
+			// v is just a bool key.
+			keys++
+		}
 	}
 	return keys
 }


### PR DESCRIPTION
With `time` option enabled, noti will append command execution time to
the message.

Closes: #94,#35