### PR TITLE
fix: Text in Telegram 

### DIFF
--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
+	"html"
+	
 	"github.com/spf13/viper"
 	"github.com/variadico/noti/service/bearychat"
 	"github.com/variadico/noti/service/keybase"
@@ -125,7 +126,7 @@ func getTelegram(title, message string, v *viper.Viper) notification {
 	return &telegram.Notification{
 		ChatID:  v.GetString("telegram.chatId"),
 		Token:   v.GetString("telegram.token"),
-		Message: fmt.Sprintf("**%s %s**\n%s", title, "🚀:", message),
+		Message: fmt.Sprintf("<b>%s %s</b>\n%s", html.EscapeString(title), "🚀:", message),
 
 		Client: httpClient,
 	}

--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -2,10 +2,10 @@ package command
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"time"
-	"html"
-	
+
 	"github.com/spf13/viper"
 	"github.com/variadico/noti/service/bearychat"
 	"github.com/variadico/noti/service/keybase"

--- a/service/telegram/telegram.go
+++ b/service/telegram/telegram.go
@@ -46,7 +46,7 @@ func (n *Notification) Send() error {
 		return errors.New("missing token")
 	}
 
-	url := fmt.Sprintf("%s/bot%s/sendMessage", API, n.Token)
+	url := fmt.Sprintf("%s/bot%s/sendMessage?parse_mode=html", API, n.Token)
 
 	payload := new(bytes.Buffer)
 	if err := json.NewEncoder(payload).Encode(n); err != nil {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9548953/89149056-2c021000-d564-11ea-9397-4c7adec21afa.png)
After:
![image](https://user-images.githubusercontent.com/9548953/89149078-39b79580-d564-11ea-9836-dc8fab49b0ef.png)

I made a PR yesterday but I was sleepy and dumb and dead and forgot about character escaping, which is fixed now