### PR TITLE
Remove deprecated 'as_user' parameter

### DIFF
--- a/service/slack/slack.go
+++ b/service/slack/slack.go
@@ -110,7 +110,6 @@ func (n *Notification) Send() error {
 		vals.Set("unfurl_links", fmt.Sprintf("%t", n.UnfurlLinks))
 		vals.Set("unfurl_media", fmt.Sprintf("%t", n.UnfurlMedia))
 		vals.Set("username", n.Username)
-		vals.Set("as_user", fmt.Sprintf("%t", n.AsUser))
 		vals.Set("icon_url", n.IconURL)
 		vals.Set("icon_emoji", n.IconEmoji)
 


### PR DESCRIPTION
The 'as_user' parameter is deprecated in the Slack API and is no longer supported.

This change addresses the "invalid_arguments" error received from the Slack API.